### PR TITLE
:memo: Fix format of contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -2,10 +2,7 @@
 
 Please note that this project is released with a [Contributor Code of Conduct](code-of-conduct.md). By participating in this project you agree to abide by its terms.
 
--
-
-Ensure your pull request adheres to the following guidelines:
-
+- Ensure your pull request adheres to the following guidelines:
 - Search previous suggestions before making a new one, as yours may be a duplicate.
 - If you just created something, wait at least a couple of weeks before submitting.
 - You should of course have read or used the thing you're submitting.


### PR DESCRIPTION
I remove the redundant newline in the first point of guidelines.
I'm not sure whether this newline is used on purpose, but I modify it by instinct of design.