### PR TITLE
Add react-p5-wrapper to the list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,7 @@ Creative coding is a different discipline than programming systems. The goal is 
 - [Paper.js](http://paperjs.org/) - The swiss army knife of vector graphics scripting.
 - [Pixi.js](http://www.pixijs.com/) - HTML 5 2D rendering engine that uses webGL with canvas fallback.
 - [p5.js](https://p5js.org/) - JavaScript library that starts with the original goal of Processing.
+- [react-p5-wrapper](https://github.com/jamesrweb/react-p5-wrapper) - A wrapper component that allows you to utilise P5.js sketches within React apps.
 - [Pts.js](https://ptsjs.org/) - JavaScript library for visualization and creative-coding.
 - [Fabric.js](http://fabricjs.com/) - Javascript canvas library, SVG-to-canvas parser.
 - [Maker.js](https://maker.js.org) - Parametric line drawing for SVG, CNC & laser cutters.

--- a/readme.md
+++ b/readme.md
@@ -178,7 +178,7 @@ Creative coding is a different discipline than programming systems. The goal is 
 - [Paper.js](http://paperjs.org/) - The swiss army knife of vector graphics scripting.
 - [Pixi.js](http://www.pixijs.com/) - HTML 5 2D rendering engine that uses webGL with canvas fallback.
 - [p5.js](https://p5js.org/) - JavaScript library that starts with the original goal of Processing.
-- [react-p5-wrapper](https://github.com/jamesrweb/react-p5-wrapper) - A wrapper component that allows you to utilise P5.js sketches within React apps.
+- [P5-wrapper/react](https://github.com/P5-wrapper/react) - A wrapper component that allows you to utilise P5.js sketches within React apps.
 - [Pts.js](https://ptsjs.org/) - JavaScript library for visualization and creative-coding.
 - [Fabric.js](http://fabricjs.com/) - Javascript canvas library, SVG-to-canvas parser.
 - [Maker.js](https://maker.js.org) - Parametric line drawing for SVG, CNC & laser cutters.


### PR DESCRIPTION
The [ react-p5-wrapper](https://github.com/P5-Wrapper/react) component allows you to render p5 sketches into react applications. You can react to prop changes, we support both typescript and javascript and the project has been adopted by [hundreds of users on npm](https://www.npmjs.com/package/react-p5-wrapper).  The library was recently updated to modern react standards and has been [built by people](https://github.com/P5-Wrapper/react/graphs/contributors) who use p5 often and know it's pain points in terms of dynamic rendering, etc. Hopefully we can get it onto the list for more users to discover the project!