### PR TITLE
Update WebGL Academy link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Creative coding is a different discipline than programming systems. The goal is 
 - [A Primer on Bézier Curves](https://pomax.github.io/bezierinfo/) - A free book for when you really need to know how to do Bézier things.
 - [3D Game Shaders For Beginners](https://lettier.github.io/3d-game-shaders-for-beginners) - Step-by-step guide to real-time shading techniques.
 - [XEM WebGL Guide](https://xem.github.io/articles/webgl-guide.html) - Step-by-step guide to WebGL.
-- [WebGL Academy](http://www.webglacademy.com/) - Learn WebGL and 3D algorithmic in a progressive and interactive way.
+- [WebGL Academy](https://web.archive.org/web/20221012200016/http://www.webglacademy.com/) - Learn WebGL and 3D algorithmic in a progressive and interactive way. (Archived)
 
 ## Courses
 


### PR DESCRIPTION
Update WebGL Academy link with web.archive.org version since the website no longer exists. #170 