### PR TITLE
Adding Canvascript

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 - [AsyncGraphics](https://github.com/heestand-xyz/AsyncGraphics) [iOS, macOS] - Open source, live graphics, async / await, Swift package, powered by Metal.
 - [Lygia](https://github.com/patriciogonzalezvivo/lygia) [Cross-platform] - Granular and multi-language (GLSL, HLSL, WGSL, MSL and CUDA) shader library designed for performance and flexibility.
 - [Fragment.tools](https://github.com/raphaelameaume/fragment) [Cross-platform] - A web development environment for creative coding.
+- [Canvascript](https://github.com/VBproDev/Canvascript) [Cross-platform] - A tool for creating HTML canvas graphics without writing code.
 
 ### Visual Programming Languages
 


### PR DESCRIPTION
### Description

Adding Canvascript to the Frameworks • Libraries • Ecosystems section
### Motivation

Canvascript is an open-source no-code tool that allows web game devs to easily render their drawings in the HTML canvas without writing code. Drawing even a single line requires mapping out an endless list of coordinates and can require upto 4 lines of code. With CS, one just has draw on the canvas with their pointer, then get the code to render it.
### Additional details

This is the link to the repo-
https://github.com/VBproDev/Canvascript

License is GPLv3 or later
