### PR TITLE
Add Graphite under "Visual Programming Languages"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 - [JOY.JS](https://ncase.me/joy/) - Realtime visual coding tool, easy to understand and aimed at beginners.
 - [Circles](http://circles.software) [iPhone, iPad, Mac] - Live graphics node editor, powered by AsyncGraphics.
 - [TIC-80](https://tic80.com/) - Make pixel art style games and art on a 240\*136 pixel screen.
+- [Graphite](https://graphite.rs) - Free, open source vector/raster graphics engine that combines a traditional layer-based editor with a node-based procedural design system.
 
 ### Sound Programming Languages
 


### PR DESCRIPTION
Feel free to move this under "Frameworks • Libraries • Ecosystems" or "Online" but based on the listed apps, I figured "Visual Programming Languages" is possibly the closest fit.

- https://graphite.rs/
- https://github.com/GraphiteEditor/Graphite
- https://editor.graphite.rs/#demo/changing-seasons (procedural example; drag the morph percentage slider in the top right panel!)

Graphite is a procedural graphics engine and node-based graphics manipulation language housed within a traditional graphic design editor environment. Unlike many others in this list which are languages that build up to creative coding from the technical angle (code), Graphite comes from the other direction and builds downwards from high-level artist-friendly design concepts to the node graph exposed beneath the hand-drawn artwork. It's capable of vector graphics and time-driven parametric animation right now. Later on, raster, SDFs, live data sources like audio/video/MIDI/WebSockets, and more that's on the roadmap. It will get considerably more capable of procedural design (more in the vein of creative coding) with the introduction of the node graph's equivalents to the Blender Geometry Nodes concepts of attributes and fields that are almost released.