### PR TITLE
Add Maxim Bifrost to "Other" Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 - [AsyncGraphics](https://github.com/heestand-xyz/AsyncGraphics) [iOS, macOS] - Open source, live graphics, async / await, Swift package, powered by Metal.
 - [Lygia](https://github.com/patriciogonzalezvivo/lygia) [Cross-platform] - Granular and multi-language (GLSL, HLSL, WGSL, MSL and CUDA) shader library designed for performance and flexibility.
 - [Fragment.tools](https://github.com/raphaelameaume/fragment) [Cross-platform] - A web development environment for creative coding.
+- [Maxim Bifrost](https://github.com/maximhq/bifrost) - A really fast and easy to use LLM Gateway solution.
 
 ### Visual Programming Languages
 


### PR DESCRIPTION
Maxim is a super lightweight and easy to use LLM Gateway solution. It's especially useful for people just entering the space because implementation is literally just a line of code, but it opens up a ton of models and systems with low overhead.

You can literally just swap out code:
````
- base_url = "https://api.openai.com"
+ base_url = "http://localhost:8080/openai"
````

See: https://github.com/maximhq/bifrost?tab=readme-ov-file#3-as-a-drop-in-replacement-zero-code-changes