### PR TITLE
Add Brushcue to the list of creative coding tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 - [AsyncGraphics](https://github.com/heestand-xyz/AsyncGraphics) [iOS, macOS] - Open source, live graphics, async / await, Swift package, powered by Metal.
 - [Lygia](https://github.com/patriciogonzalezvivo/lygia) [Cross-platform] - Granular and multi-language (GLSL, HLSL, WGSL, MSL and CUDA) shader library designed for performance and flexibility.
 - [Fragment.tools](https://github.com/raphaelameaume/fragment) [Cross-platform] - A web development environment for creative coding.
+- [Brushcue](https://www.brushcue.com/docs/py)[Cross-platform] - Image editing and shaders in Python.
 
 ### Visual Programming Languages
 


### PR DESCRIPTION
The link to the package is [here](https://www.brushcue.com/docs/py).  It is a Python API for image editing including the operations you see in the documentation. Additionally, it has an associated website [here](https://www.brushcue.com/). 

It is open source.

Full disclosure, this is something that I have built. 