### PR TITLE
Add Phosphor — web-based oscilloscope simulator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,6 +228,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 - [tixy.land](https://tixy.land/) - The most minimalist creative coding environment is alive.
 - [BBC Micro bot](https://www.bbcmicrobot.com/) - Run your tweet on an 8-bit computer emulator.
 - [Hydra](https://hydra.ojack.xyz/) - Live code-able video synth and coding environment.
+- [Phosphor](https://hubertlim.github.io/oscilloscope_playground/) - Web-based oscilloscope simulator with multi-pass phosphor rendering, CRT effects, and audio visualization. (Three.js, GLSL, WebGL)
 
 ### Hardware
 


### PR DESCRIPTION
## Phosphor — Oscilloscope Simulator

**Link:** https://hubertlim.github.io/oscilloscope_playground/
**Repo:** https://github.com/hubertlim/oscilloscope_playground

A web-based oscilloscope simulator with a physically-inspired multi-pass phosphor rendering pipeline. Features Lissajous figures, waveform synthesis, real-time audio visualization, and freehand vector drawing — all rendered through a 4-pass GLSL shader pipeline (beam, phosphor decay, bloom, CRT composite).

**Why it fits:** It's a creative coding tool/playground built with Three.js, GLSL, and WebGL. It sits naturally alongside other online creative coding environments like Shadertoy and Hydra.

**Section:** Online

- [x] Open source (MIT)
- [x] Live demo available
- [x] Actively maintained
- [x] Follows the contribution guidelines