### PR TITLE
Add ArcadeLab

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,6 +228,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 - [tixy.land](https://tixy.land/) - The most minimalist creative coding environment is alive.
 - [BBC Micro bot](https://www.bbcmicrobot.com/) - Run your tweet on an 8-bit computer emulator.
 - [Hydra](https://hydra.ojack.xyz/) - Live code-able video synth and coding environment.
+- [ArcadeLab](https://arcadelab.ai/) - Free no-signup host for single-file HTML creative coding — sketches, visualizations, simulations, and interactive explainers. Paste a complete HTML file, get a permanent shareable URL.
 
 ### Hardware
 


### PR DESCRIPTION
Adding ArcadeLab to Tools > Online.

**[ArcadeLab](https://arcadelab.ai/)** is a free no-signup hosting platform for single-file HTML creative coding work — generative art sketches, physics simulations, interactive visualizations, animated explainers. Paste a complete HTML file at arcadelab.ai/publish, get a permanent shareable URL.

Why it fits the list:
- Designed specifically for the single-HTML-file format that creative coding often produces (p5.js, three.js, D3, Canvas, WebGL all work natively)
- Sibling-spirit to OpenProcessing / ShaderGif / NEORT (which are already in the Online section) — community gallery for creative output
- One concrete example of what kind of work it hosts: [an interactive double-slit experiment demo](https://arcadelab.ai/play/light-wave-or-particle-ultraviper34)
- Free, open source ([github.com/mlapeter/arcadelab](https://github.com/mlapeter/arcadelab)), no account or email required to publish

Added at the bottom of Tools > Online per CONTRIBUTING.md. Followed the format `[Name](link) - Description.` with capitalized start and trailing period. Single PR for the single suggestion.

Thanks for maintaining the list!