### PR TITLE
Add img2svg-animation project link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,6 +230,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 - [Hydra](https://hydra.ojack.xyz/) - Live code-able video synth and coding environment.
 - [editor.textmode.art](https://editor.textmode.art) - Online web editor for textmode.js.
 - [synth.textmode.art](https://synth.textmode.art) - Online live coding environment for textmode.js.
+- [img2svg-animation](https://img2svg-animation.vercel.app/) - convert an image into a self-drawing SVG animation.
 
 ### Hardware
 


### PR DESCRIPTION
Adds [img2svg-animation](https://img2svg-animation.vercel.app/) to the Online section.

It's a free browser tool that traces an uploaded image into single-color SVG line art, then animates the paths so they draw themselves like a pen sketch.


https://github.com/user-attachments/assets/1f3a7044-61bd-4610-9074-0eb9fed29180


* Upload an image, get traced SVG line art (adjustable threshold, invert)
* Animation controls: duration, delay, easing, direction, looping, fade-in
* Export as SVG, downloadable file, or self-contained HTML
* Open source, MIT licensed
* Repo: https://github.com/a1stok/img2svg-animation